### PR TITLE
Add pagination support and tag index page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll-admin', group: :jekyll_plugins
+gem 'jekyll-paginate', group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -14,5 +14,9 @@ theme: minima
 
 plugins:
   - jekyll-remote-theme
+  - jekyll-paginate
+
+paginate: 10
+paginate_path: "/page:num/"
 
 remote_theme: terryoy/minima 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,60 @@
+---
+layout: default
+---
+<div class="home">
+  {%- if page.title -%}
+    <h1 class="page-heading">{{ page.title }}</h1>
+  {%- endif -%}
+
+  {%- if paginator -%}
+    {%- assign posts = paginator.posts -%}
+  {%- else -%}
+    {%- assign posts = site.posts -%}
+  {%- endif -%}
+
+  {%- if posts.size > 0 -%}
+    {%- if page.list_title -%}
+      <h2 class="post-list-heading">{{ page.list_title }}</h2>
+    {%- endif -%}
+    <ul class="post-list">
+      {%- for post in posts -%}
+        <li>
+          <span class="post-meta">{{ post.date | date: "%Y-%m-%d" }}</span>
+          <h2>
+            <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+          </h2>
+          {%- if site.show_excerpts -%}
+            {{ post.excerpt }}
+          {%- endif -%}
+          {%- if post.tags and post.tags.size > 0 -%}
+            <p class="post-tags">
+              {%- for tag in post.tags -%}
+                <a class="tag" href="{{ '/tags/#' | append: (tag | slugify) | relative_url }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
+              {%- endfor -%}
+            </p>
+          {%- endif -%}
+        </li>
+      {%- endfor -%}
+    </ul>
+
+    {%- if paginator and paginator.total_pages > 1 -%}
+      <nav class="pagination" role="navigation">
+        {%- if paginator.previous_page -%}
+          <a class="previous" href="{{ paginator.previous_page_path | relative_url }}">&laquo; 上一页</a>
+        {%- else -%}
+          <span class="previous disabled">&laquo; 上一页</span>
+        {%- endif -%}
+
+        <span class="page-number">第 {{ paginator.page }} / {{ paginator.total_pages }} 页</span>
+
+        {%- if paginator.next_page -%}
+          <a class="next" href="{{ paginator.next_page_path | relative_url }}">下一页 &raquo;</a>
+        {%- else -%}
+          <span class="next disabled">下一页 &raquo;</span>
+        {%- endif -%}
+      </nav>
+    {%- endif -%}
+  {%- else -%}
+    <p>没有文章。</p>
+  {%- endif -%}
+</div>

--- a/tags.md
+++ b/tags.md
@@ -1,0 +1,29 @@
+---
+layout: page
+title: 标签
+description: 按照标签浏览博客文章
+permalink: /tags/
+---
+
+{%- assign tags = site.tags | sort_natural -%}
+{%- if tags and tags.size > 0 -%}
+<ul class="tag-index">
+  {%- for tag in tags -%}
+    {%- assign tag_name = tag[0] -%}
+    {%- assign tag_posts = tag[1] | sort: 'date' | reverse -%}
+    <li id="{{ tag_name | slugify }}">
+      <h2>{{ tag_name }} <span class="tag-count">({{ tag_posts.size }})</span></h2>
+      <ul class="tag-posts">
+        {%- for post in tag_posts -%}
+          <li>
+            <span class="post-meta">{{ post.date | date: "%Y-%m-%d" }}</span>
+            <a href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+          </li>
+        {%- endfor -%}
+      </ul>
+    </li>
+  {%- endfor -%}
+</ul>
+{%- else -%}
+<p>暂无标签。</p>
+{%- endif -%}


### PR DESCRIPTION
## Summary
- enable the Jekyll pagination plugin and configure the site to split the home feed into pages
- override the home layout to render paginated post listings with tag links
- add a dedicated tag archive page to browse posts grouped by tag

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68edcf2565288331af3f53138393eb9d