### PR TITLE
Fix jekyll-admin dependency resolution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ ruby ">= 2.7"
 source "https://rubygems.org"
 
 gem 'github-pages', group: :jekyll_plugins
-gem 'jekyll-admin', group: :jekyll_plugins
+gem 'jekyll-admin', '~> 0.12.0', group: :jekyll_plugins
 gem 'jekyll-paginate', group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
-    jekyll-admin (0.12.2)
+    jekyll-admin (0.12.0)
       activesupport (>= 4.2, < 8.0)
       jekyll (>= 3.7, < 5.0)
       mercenary (~> 0.3)


### PR DESCRIPTION
## Summary
- pin jekyll-admin to the latest available 0.12.0 release to avoid fetching a removed gem
- update the lockfile to match the new jekyll-admin version

## Testing
- bundle install *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_68ee176e0a288331ae72c5a262476133