### PR TITLE
Fix tag slug generation

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -29,7 +29,8 @@ layout: default
           {%- if post.tags and post.tags.size > 0 -%}
             <p class="post-tags">
               {%- for tag in post.tags -%}
-                <a class="tag" href="{{ '/tags/#' | append: (tag | slugify) | relative_url }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
+                {%- assign tag_slug = tag | slugify -%}
+                <a class="tag" href="{{ '/tags/#' | append: tag_slug | relative_url }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
               {%- endfor -%}
             </p>
           {%- endif -%}

--- a/tags.md
+++ b/tags.md
@@ -9,7 +9,8 @@ permalink: /tags/
 {%- if tags and tags.size > 0 -%}
 <ul class="tag-index">
   {%- for tag in tags -%}
-    {%- assign tag_name = tag[0] -%}
+    {%- assign tag_name_raw = tag[0] -%}
+    {%- capture tag_name -%}{{ tag_name_raw }}{%- endcapture -%}
     {%- assign tag_posts = tag[1] | sort: 'date' | reverse -%}
     <li id="{{ tag_name | slugify }}">
       <h2>{{ tag_name }} <span class="tag-count">({{ tag_posts.size }})</span></h2>


### PR DESCRIPTION
## Summary
- ensure tag names are captured as strings before slugifying them on the tags index
- update the home layout to compute tag slugs without triggering Liquid syntax warnings

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ee19356780833193c22c9e2c59567e