### PR TITLE
Fix pagination by using HTML index template

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,4 +2,3 @@
 layout: home
 published: true
 ---
-


### PR DESCRIPTION
## Summary
- replace the Markdown index page with an HTML counterpart so Jekyll pagination can use it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ee1f42f31083319c6fcaf58a748579